### PR TITLE
TASK: Pin phpunit/phpunit-mock-objects to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "typo3/kickstart": "~2.3.0",
         "typo3/buildessentials": "2.3.x-dev",
         "phpunit/phpunit": "~4.8 || ~5.2.0",
+        "phpunit/phpunit-mock-objects": "~3.1.0",
         "mikey179/vfsstream": "~1.6"
     },
     "suggest": {


### PR DESCRIPTION
This "fixes" the test failures caused by changes in the mock objects library.
