### PR TITLE
TASK: Add missing repositories/distributionPackages configuration to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,12 @@
         "phpunit/phpunit": "~6.0.0",
         "mikey179/vfsstream": "~1.6"
     },
+    "repositories": {
+        "distributionPackages": {
+            "type": "path",
+            "url": "./DistributionPackages/*"
+        }
+    },
     "replace": {
         "typo3/flow-base-distribution": "self.version"
     },


### PR DESCRIPTION
On a fresh installed base distribution, the repositories section is missing. `./flow package:create` depends blindly on that key and throws an exception.

Resolves: https://github.com/neos/flow-development-collection/issues/1489