### PR TITLE
!!! Raise phpunit to v8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "neos/kickstarter": "dev-master",
         "neos/buildessentials": "dev-master",
         "neos/behat": "dev-master",
-        "phpunit/phpunit": "~6.0.0",
+        "phpunit/phpunit": "~8.1",
         "mikey179/vfsstream": "~1.6"
     },
     "repositories": {


### PR DESCRIPTION
This change raises the phpunit requirement to v8.1. This might be breaking for you as phpunit introduced return types on methods like `public setUp(): void` as well as `public tearDown(): void`. PHPUnit also deprecated a lot of methods. You might find [here](https://thephp.cc/news/2019/02/help-my-tests-stopped-working) some more background information about replacements for your assertions.