### PR TITLE
FIX: neos/behat should be a dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,11 @@
     },
     "require": {
         "neos/flow": "~7.3.0",
-        "neos/welcome": "~7.3.0",
-        "neos/behat": "~7.3.0"
+        "neos/welcome": "~7.3.0"
     },
     "require-dev": {
         "neos/kickstarter": "~7.3.0",
+        "neos/behat": "~7.3.0",
         "neos/buildessentials": "~7.3.0",
         "phpunit/phpunit": "~9.0",
         "mikey179/vfsstream": "~1.6"


### PR DESCRIPTION
Behat being a "normal" require breaks my CI scripts for matrix test execution (where I need to remove behat) for Flow 7.3 projects - in 6.3 and 8.2 it already is a dev dependency - so I'm quiiiiite sure, it should be for 7.3, too ;)